### PR TITLE
Fix RUBY_VERSION to 3.4.5 in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,3 @@
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version
-ARG RUBY_VERSION=3.4.4
+ARG RUBY_VERSION=3.4.5
 FROM ghcr.io/rails/devcontainer/images/ruby:$RUBY_VERSION


### PR DESCRIPTION
Fixed ruby version difference

- .ruby-version
  - `3.4.5`
- Dockerfile
  - `ARG RUBY_VERSION=3.4.4`